### PR TITLE
회원, 비밀번호 인증 토큰 관련 API 수정

### DIFF
--- a/src/main/java/com/twentyone/steachserver/GlobalControllerAdvice.java
+++ b/src/main/java/com/twentyone/steachserver/GlobalControllerAdvice.java
@@ -6,6 +6,7 @@ import com.twentyone.steachserver.domain.curriculum.error.DuplicatedCurriculumRe
 import com.twentyone.steachserver.domain.lecture.error.LectureTimeNotYetException;
 import com.twentyone.steachserver.global.error.ErrorCode;
 import com.twentyone.steachserver.global.error.ErrorResponseDto;
+import com.twentyone.steachserver.global.error.ResourceNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +44,12 @@ public class GlobalControllerAdvice {
     public ResponseEntity<ErrorResponseDto> handleAuthCodeAlreadyInUseException(AuthCodeAlreadyInUseException e) {
         log.info(e.getMessage());
         return getResponse(ErrorCode.AUTH_CODE_ALREADY_IN_USE);
+    }
+
+    @ExceptionHandler(AuthCodeAlreadyInUseException.class)
+    public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException e) {
+        log.info(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
     private static ResponseEntity<ErrorResponseDto> getResponse(ErrorCode errorCode) {

--- a/src/main/java/com/twentyone/steachserver/GlobalControllerAdvice.java
+++ b/src/main/java/com/twentyone/steachserver/GlobalControllerAdvice.java
@@ -46,7 +46,7 @@ public class GlobalControllerAdvice {
         return getResponse(ErrorCode.AUTH_CODE_ALREADY_IN_USE);
     }
 
-    @ExceptionHandler(AuthCodeAlreadyInUseException.class)
+    @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException e) {
         log.info(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());

--- a/src/main/java/com/twentyone/steachserver/GlobalControllerAdvice.java
+++ b/src/main/java/com/twentyone/steachserver/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package com.twentyone.steachserver;
 
 import com.twentyone.steachserver.domain.auth.error.AuthCodeAlreadyInUseException;
 import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
+import com.twentyone.steachserver.domain.auth.error.UnAuthorizedException;
 import com.twentyone.steachserver.domain.curriculum.error.DuplicatedCurriculumRegistrationException;
 import com.twentyone.steachserver.domain.lecture.error.LectureTimeNotYetException;
 import com.twentyone.steachserver.global.error.ErrorCode;
@@ -50,6 +51,12 @@ public class GlobalControllerAdvice {
     public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException e) {
         log.info(e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResponseEntity<String> handleUnAuthorizedException(UnAuthorizedException e) {
+        log.info(e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
     }
 
     private static ResponseEntity<ErrorResponseDto> getResponse(ErrorCode errorCode) {

--- a/src/main/java/com/twentyone/steachserver/config/security/ApplicationConfig.java
+++ b/src/main/java/com/twentyone/steachserver/config/security/ApplicationConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -20,7 +21,7 @@ public class ApplicationConfig {
     @Bean
     public UserDetailsService userDetailsService() {
         return username -> loginCredentialRepository.findByUsername(username)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 
     @Bean

--- a/src/main/java/com/twentyone/steachserver/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/twentyone/steachserver/config/security/JwtAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 userDetails = this.userDetailsService.loadUserByUsername(userId);
             } catch (UsernameNotFoundException e) {
-                throw new JwtException("찾을 수 없는 사용자");
+                throw new JwtException("[JwtToken] 찾을 수 없는 사용자");
             }
 
             jwtService.validateToken(jwt, userDetails);

--- a/src/main/java/com/twentyone/steachserver/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/twentyone/steachserver/config/security/JwtAuthenticationFilter.java
@@ -48,12 +48,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails;
             try {
+                //로그인 아이디로 사용자를 찾는다
                 userDetails = this.userDetailsService.loadUserByUsername(userId);
             } catch (UsernameNotFoundException e) {
                 throw new JwtException("[JwtToken] 찾을 수 없는 사용자");
             }
-
-            jwtService.validateToken(jwt, userDetails);
 
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     userDetails,

--- a/src/main/java/com/twentyone/steachserver/config/security/JwtExceptionFilter.java
+++ b/src/main/java/com/twentyone/steachserver/config/security/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
-package com.twentyone.steachserver.domain.auth.dto;
+package com.twentyone.steachserver.config.security;
 
+import com.twentyone.steachserver.domain.auth.dto.JwtExceptionResponse;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/twentyone/steachserver/config/security/JwtExceptionFilter.java
+++ b/src/main/java/com/twentyone/steachserver/config/security/JwtExceptionFilter.java
@@ -1,6 +1,7 @@
 package com.twentyone.steachserver.config.security;
 
 import com.twentyone.steachserver.domain.auth.dto.JwtExceptionResponse;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -15,16 +16,18 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
         try {
             chain.doFilter(req, res);
-        } catch (JwtException | IOException ex) {
-            setErrorResponse(HttpStatus.UNAUTHORIZED, res, ex);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, res, "만료된 토큰입니다.");
+        } catch (JwtException | IOException e) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, res, e.getMessage());
         }
     }
 
-    public void setErrorResponse(HttpStatus status, HttpServletResponse res, Throwable ex) throws IOException {
+    public void setErrorResponse(HttpStatus status, HttpServletResponse res, String errorMessage) throws IOException {
         res.setStatus(status.value());
         res.setContentType("application/json; charset=UTF-8");
 
-        JwtExceptionResponse jwtExceptionResponse = new JwtExceptionResponse(status, ex.getMessage());
+        JwtExceptionResponse jwtExceptionResponse = new JwtExceptionResponse(status, errorMessage);
         res.getWriter().write(jwtExceptionResponse.convertToJson());
     }
 }

--- a/src/main/java/com/twentyone/steachserver/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/twentyone/steachserver/config/security/SecurityConfiguration.java
@@ -1,6 +1,5 @@
 package com.twentyone.steachserver.config.security;
 
-import com.twentyone.steachserver.domain.auth.dto.JwtExceptionFilter;
 import com.twentyone.steachserver.domain.auth.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
@@ -55,9 +55,6 @@ public class AuthController {
     @Operation(summary = "[인증된 사용자] 비밀번호 체크", description = "60분짜리 임시토큰이 발급됩니다. 회원정보 수정 시 사용합니다.")
     @PostMapping("/check/password")
     public ResponseEntity<MemberCheckPasswordResponseDto> checkPassword(@AuthenticationPrincipal LoginCredential loginCredential, @RequestBody MemberCheckPasswordRequestDto checkPasswordRequestDto) {
-
-        log.info(checkPasswordRequestDto.password());
-
         return ResponseEntity.ok(authService.checkPassword(loginCredential, checkPasswordRequestDto));
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.twentyone.steachserver.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
+@Slf4j
 @Tag(name = "인증")
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -50,9 +52,12 @@ public class AuthController {
         return ResponseEntity.ok(authService.checkUsernameAvailability(username));
     }
 
-    @Operation(summary = "[All] 비밀번호 체크")
+    @Operation(summary = "[인증된 사용자] 비밀번호 체크")
     @PostMapping("/check/password")
     public ResponseEntity<MemberCheckPasswordResponseDto> checkPassword(@AuthenticationPrincipal LoginCredential loginCredential, @RequestBody MemberCheckPasswordRequestDto checkPasswordRequestDto) {
-        return ResponseEntity.ok(MemberCheckPasswordResponseDto.of(authService.checkPassword(loginCredential, checkPasswordRequestDto)));
+
+        log.info(checkPasswordRequestDto.password());
+
+        return ResponseEntity.ok(authService.checkPassword(loginCredential, checkPasswordRequestDto));
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
@@ -52,7 +52,7 @@ public class AuthController {
         return ResponseEntity.ok(authService.checkUsernameAvailability(username));
     }
 
-    @Operation(summary = "[인증된 사용자] 비밀번호 체크")
+    @Operation(summary = "[인증된 사용자] 비밀번호 체크", description = "60분짜리 임시토큰이 발급됩니다. 회원정보 수정 시 사용합니다.")
     @PostMapping("/check/password")
     public ResponseEntity<MemberCheckPasswordResponseDto> checkPassword(@AuthenticationPrincipal LoginCredential loginCredential, @RequestBody MemberCheckPasswordRequestDto checkPasswordRequestDto) {
 

--- a/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 public class AuthController {
     private final AuthService authService;
 
+    @Transactional
     @Operation(summary = "[All] 학생 회원가입!", description = "username은 빈칸 불가능, 숫자로 시작 불가능, 영어와 숫자 조합만 가능")
     @PostMapping("/student/join")
     public ResponseEntity<LoginResponseDto> signupStudent(@RequestBody StudentSignUpDto studentSignUpDto) {
@@ -32,6 +34,7 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(loginResponseDto);
     }
 
+    @Transactional
     @Operation(summary = "[All] 강사 회원가입!", description = "username은 빈칸 불가능, 숫자로 시작 불가능, 영어와 숫자 조합만 가능/ file은 첨부하지 않아도 됨(추후 변경예정) <br/> auth_code 사용안한 것만 가능")
     @PostMapping(value = "/teacher/join", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<LoginResponseDto> signupTeacher(@RequestPart(value = "file", required = false) MultipartFile file, @RequestPart("teacherSignUpDto") TeacherSignUpDto teacherSignUpDto) throws IOException {
@@ -56,5 +59,14 @@ public class AuthController {
     @PostMapping("/check/password")
     public ResponseEntity<MemberCheckPasswordResponseDto> checkPassword(@AuthenticationPrincipal LoginCredential loginCredential, @RequestBody MemberCheckPasswordRequestDto checkPasswordRequestDto) {
         return ResponseEntity.ok(authService.checkPassword(loginCredential, checkPasswordRequestDto));
+    }
+
+    @Operation(summary = "[인증된 사용자] 회원 삭제", description = "강사일 때, 내가 만든 커리큘럼은 삭제되지 않음")
+    @Transactional
+    @DeleteMapping("/member")
+    public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal LoginCredential loginCredential) {
+        authService.deleteMember(loginCredential);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/controller/AuthController.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 public class AuthController {
     private final AuthService authService;
 
-    @Transactional
     @Operation(summary = "[All] 학생 회원가입!", description = "username은 빈칸 불가능, 숫자로 시작 불가능, 영어와 숫자 조합만 가능")
     @PostMapping("/student/join")
     public ResponseEntity<LoginResponseDto> signupStudent(@RequestBody StudentSignUpDto studentSignUpDto) {
@@ -34,7 +33,6 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(loginResponseDto);
     }
 
-    @Transactional
     @Operation(summary = "[All] 강사 회원가입!", description = "username은 빈칸 불가능, 숫자로 시작 불가능, 영어와 숫자 조합만 가능/ file은 첨부하지 않아도 됨(추후 변경예정) <br/> auth_code 사용안한 것만 가능")
     @PostMapping(value = "/teacher/join", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<LoginResponseDto> signupTeacher(@RequestPart(value = "file", required = false) MultipartFile file, @RequestPart("teacherSignUpDto") TeacherSignUpDto teacherSignUpDto) throws IOException {
@@ -62,7 +60,6 @@ public class AuthController {
     }
 
     @Operation(summary = "[인증된 사용자] 회원 삭제", description = "강사일 때, 내가 만든 커리큘럼은 삭제되지 않음")
-    @Transactional
     @DeleteMapping("/member")
     public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal LoginCredential loginCredential) {
         authService.deleteMember(loginCredential);

--- a/src/main/java/com/twentyone/steachserver/domain/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/dto/LoginResponseDto.java
@@ -2,7 +2,6 @@ package com.twentyone.steachserver.domain.auth.dto;
 
 import com.twentyone.steachserver.domain.member.dto.MemberInfoResponse;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,13 +12,13 @@ public class LoginResponseDto extends MemberInfoResponse {
     private String token;
     private Role role;
 
-    public static LoginResponseDto of(String token, Role role, String username, String name, String email) {
+    public static LoginResponseDto of(String token, Role role, String username, String nickname, String email) {
         LoginResponseDto dto = new LoginResponseDto();
 
         dto.token = token;
         dto.role = role;
         dto.username = username;
-        dto.name = name;
+        dto.nickname = nickname;
         dto.email = email;
 
         return dto;

--- a/src/main/java/com/twentyone/steachserver/domain/auth/dto/MemberCheckPasswordResponseDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/dto/MemberCheckPasswordResponseDto.java
@@ -1,7 +1,7 @@
 package com.twentyone.steachserver.domain.auth.dto;
 
-public record MemberCheckPasswordResponseDto(String tempToken) {
-    public static MemberCheckPasswordResponseDto of(String tempToken) {
-        return new MemberCheckPasswordResponseDto(tempToken);
+public record MemberCheckPasswordResponseDto(String passwordAuthToken) {
+    public static MemberCheckPasswordResponseDto of(String passwordAuthToken) {
+        return new MemberCheckPasswordResponseDto(passwordAuthToken);
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/dto/MemberCheckPasswordResponseDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/dto/MemberCheckPasswordResponseDto.java
@@ -1,7 +1,7 @@
 package com.twentyone.steachserver.domain.auth.dto;
 
-public record MemberCheckPasswordResponseDto(Boolean isCorrect) {
-    public static MemberCheckPasswordResponseDto of(Boolean isCorrect) {
-        return new MemberCheckPasswordResponseDto(isCorrect);
+public record MemberCheckPasswordResponseDto(String tempToken) {
+    public static MemberCheckPasswordResponseDto of(String tempToken) {
+        return new MemberCheckPasswordResponseDto(tempToken);
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/dto/StudentSignUpDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/dto/StudentSignUpDto.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class StudentSignUpDto {
     private String username;
     private String password;
-    private String name;
+    private String nickname;
     private String auth_code;
     private String email;
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/dto/TeacherSignUpDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/dto/TeacherSignUpDto.java
@@ -21,6 +21,6 @@ import lombok.NoArgsConstructor;
 public class TeacherSignUpDto {
     private String username;
     private String password;
-    private String name;
+    private String nickname;
     private String email;
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/error/UnAuthorizedException.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/error/UnAuthorizedException.java
@@ -1,0 +1,10 @@
+package com.twentyone.steachserver.domain.auth.error;
+
+public class UnAuthorizedException extends RuntimeException {
+    public UnAuthorizedException() {
+    }
+
+    public UnAuthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthService.java
@@ -16,4 +16,6 @@ public interface AuthService {
     CheckUsernameAvailableResponse checkUsernameAvailability(String username);
 
     MemberCheckPasswordResponseDto checkPassword(LoginCredential loginCredential, MemberCheckPasswordRequestDto checkPasswordRequestDto);
+
+    void deleteMember(LoginCredential loginCredential);
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthService.java
@@ -15,5 +15,5 @@ public interface AuthService {
 
     CheckUsernameAvailableResponse checkUsernameAvailability(String username);
 
-    Boolean checkPassword(LoginCredential loginCredential, MemberCheckPasswordRequestDto checkPasswordRequestDto);
+    MemberCheckPasswordResponseDto checkPassword(LoginCredential loginCredential, MemberCheckPasswordRequestDto checkPasswordRequestDto);
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Optional;
 
 @Transactional(readOnly = true)
 @Slf4j
@@ -159,6 +158,6 @@ public class AuthServiceImpl implements AuthService {
             throw new ForbiddenException("패스워드 일치하지 않음");
         }
 
-        return MemberCheckPasswordResponseDto.of(jwtService.generateTempToken(loginCredential));
+        return MemberCheckPasswordResponseDto.of(jwtService.generatePasswordAuthToken(loginCredential));
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
@@ -160,4 +160,9 @@ public class AuthServiceImpl implements AuthService {
 
         return MemberCheckPasswordResponseDto.of(jwtService.generatePasswordAuthToken(loginCredential));
     }
+
+    @Override
+    public void deleteMember(LoginCredential loginCredential) {
+        loginCredentialRepository.delete(loginCredential);
+    }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
@@ -105,7 +105,7 @@ public class AuthServiceImpl implements AuthService {
         String encodedPassword = passwordEncoder.encode(studentSignUpDto.getPassword());
 
         //student 저장
-        Student student = Student.of(studentSignUpDto.getUsername(), encodedPassword, studentSignUpDto.getName(), studentSignUpDto.getEmail());
+        Student student = Student.of(studentSignUpDto.getUsername(), encodedPassword, studentSignUpDto.getNickname(), studentSignUpDto.getEmail());
         studentRepository.save(student);
 
         String accessToken = jwtService.generateAccessToken(student);
@@ -128,7 +128,7 @@ public class AuthServiceImpl implements AuthService {
         String encodedPassword = passwordEncoder.encode(teacherSignUpDto.getPassword());
 
         //Teacher 저장
-        Teacher teacher = Teacher.of(teacherSignUpDto.getUsername(), encodedPassword, teacherSignUpDto.getName(),
+        Teacher teacher = Teacher.of(teacherSignUpDto.getUsername(), encodedPassword, teacherSignUpDto.getNickname(),
                 teacherSignUpDto.getEmail(), fileName);
         teacherRepository.save(teacher);
 

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/AuthServiceImpl.java
@@ -162,6 +162,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional
     public void deleteMember(LoginCredential loginCredential) {
         loginCredentialRepository.delete(loginCredential);
     }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
@@ -24,7 +24,7 @@ public class JwtService {
     private String SECRET_KEY;
 
     public static long accessTokenValidTime = Duration.ofMinutes(200).toMillis(); // 만료시간 30분
-    public static long passwordAuthTokenValidTime = Duration.ofMinutes(1).toMillis(); // 만료시간 1분
+    public static long passwordAuthTokenValidTime = Duration.ofMinutes(60).toMillis(); // 만료시간 1분
 
     public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
@@ -62,11 +62,23 @@ public class JwtService {
         return generateToken(new HashMap<>(), userDetails, "temp", tempTokenValidTime);
     }
 
+    //TODO isAccessTokenValid로 변경
     public boolean isTokenValid(String token, UserDetails userDetails) {
         final String username = extractUsername(token);
         boolean b = (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
 
         return b;
+    }
+
+    public boolean isTempTokenValid(String token, UserDetails userDetails) {
+        try {
+            final String username = extractUsername(token);
+            boolean b = (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+
+            return b;
+        } catch (RuntimeException e) {
+            return false;
+        }
     }
 
     public boolean isTokenExpired(String token) {

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
@@ -1,8 +1,6 @@
 package com.twentyone.steachserver.domain.auth.service;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +68,16 @@ public class JwtService {
         return b;
     }
 
+    public void validateToken(String token, UserDetails userDetails) {
+//        if (isTokenExpired(token)) {
+//            throw new ExpiredJwtException();
+//        }
+        final String username = extractUsername(token);
+        if (!username.equals(userDetails.getUsername())) {
+            throw new JwtException("사용자 에러");
+        }
+    }
+
     public boolean isPasswordAuthTokenValid(String token, UserDetails userDetails) {
         try {
             final String username = extractUsername(token);
@@ -100,7 +108,6 @@ public class JwtService {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-
     }
 
     private SecretKey getSignInKey() {

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
@@ -26,7 +26,7 @@ public class JwtService {
     private String SECRET_KEY;
 
     public static long accessTokenValidTime = Duration.ofMinutes(200).toMillis(); // 만료시간 30분
-    public static long tempTokenValidTime = Duration.ofMinutes(1).toMillis(); // 만료시간 1분
+    public static long passwordAuthTokenValidTime = Duration.ofMinutes(1).toMillis(); // 만료시간 1분
 
     public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);
@@ -58,8 +58,8 @@ public class JwtService {
         return generateToken(new HashMap<>(), userDetails, "access", accessTokenValidTime);
     }
 
-    public String generateTempToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails, "temp", tempTokenValidTime);
+    public String generatePasswordAuthToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails, "temp", passwordAuthTokenValidTime);
     }
 
     //TODO isAccessTokenValid로 변경
@@ -70,7 +70,7 @@ public class JwtService {
         return b;
     }
 
-    public boolean isTempTokenValid(String token, UserDetails userDetails) {
+    public boolean isPasswordAuthTokenValid(String token, UserDetails userDetails) {
         try {
             final String username = extractUsername(token);
             boolean b = (username.equals(userDetails.getUsername())) && !isTokenExpired(token);

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
@@ -26,6 +26,7 @@ public class JwtService {
     private String SECRET_KEY;
 
     public static long accessTokenValidTime = Duration.ofMinutes(200).toMillis(); // 만료시간 30분
+    public static long tempTokenValidTime = Duration.ofMinutes(1).toMillis(); // 만료시간 1분
 
     public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);
@@ -40,15 +41,13 @@ public class JwtService {
     public String generateToken(
             Map<String, Object> extraClaims,
             UserDetails userDetails,
-            String tokenType //access, refresh
+            String tokenType, //access, refresh
+            long durationTime
     ) {
-        long durationTime = accessTokenValidTime;
-
         return Jwts.builder()
                 .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + durationTime))
                 .claim("token_type", tokenType)
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
@@ -56,7 +55,11 @@ public class JwtService {
     }
 
     public String generateAccessToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails, "access");
+        return generateToken(new HashMap<>(), userDetails, "access", accessTokenValidTime);
+    }
+
+    public String generateTempToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails, "temp", tempTokenValidTime);
     }
 
     public boolean isTokenValid(String token, UserDetails userDetails) {

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/JwtService.java
@@ -23,8 +23,8 @@ public class JwtService {
     @Value("${jwt.secretKey}")
     private String SECRET_KEY;
 
-    public static long accessTokenValidTime = Duration.ofMinutes(200).toMillis(); // 만료시간 30분
-    public static long passwordAuthTokenValidTime = Duration.ofMinutes(60).toMillis(); // 만료시간 1분
+    public static long accessTokenValidTime = Duration.ofMinutes(200).toMillis(); // 만료시간 200분
+    public static long passwordAuthTokenValidTime = Duration.ofMinutes(60).toMillis(); // 만료시간 60분
 
     public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);
@@ -66,16 +66,6 @@ public class JwtService {
         boolean b = (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
 
         return b;
-    }
-
-    public void validateToken(String token, UserDetails userDetails) {
-//        if (isTokenExpired(token)) {
-//            throw new ExpiredJwtException();
-//        }
-        final String username = extractUsername(token);
-        if (!username.equals(userDetails.getUsername())) {
-            throw new JwtException("사용자 에러");
-        }
     }
 
     public boolean isPasswordAuthTokenValid(String token, UserDetails userDetails) {

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/PasswordAuthTokenService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/PasswordAuthTokenService.java
@@ -2,6 +2,6 @@ package com.twentyone.steachserver.domain.auth.service;
 
 import com.twentyone.steachserver.domain.auth.model.LoginCredential;
 
-public interface TempTokenService {
+public interface PasswordAuthTokenService {
     void validateToken(String token, LoginCredential credential);
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/PasswordAuthTokenServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/PasswordAuthTokenServiceImpl.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class TempTokenServiceImpl implements TempTokenService {
+public class PasswordAuthTokenServiceImpl implements PasswordAuthTokenService {
     private final JwtService jwtService;
 
     @Override
-    public void validateToken(String token, LoginCredential credential) {
-        if (!jwtService.isTempTokenValid(token, credential)) {
+    public void validateToken(String passwordAuthToken, LoginCredential credential) {
+        if (!jwtService.isPasswordAuthTokenValid(passwordAuthToken, credential)) {
             throw new ForbiddenException("토큰이 유효하지 않음");
         }
     }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/PasswordAuthTokenServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/PasswordAuthTokenServiceImpl.java
@@ -1,6 +1,6 @@
 package com.twentyone.steachserver.domain.auth.service;
 
-import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
+import com.twentyone.steachserver.domain.auth.error.UnAuthorizedException;
 import com.twentyone.steachserver.domain.auth.model.LoginCredential;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,7 +13,7 @@ public class PasswordAuthTokenServiceImpl implements PasswordAuthTokenService {
     @Override
     public void validateToken(String passwordAuthToken, LoginCredential credential) {
         if (!jwtService.isPasswordAuthTokenValid(passwordAuthToken, credential)) {
-            throw new ForbiddenException("토큰이 유효하지 않음");
+            throw new UnAuthorizedException("토큰이 유효하지 않음");
         }
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/TempTokenService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/TempTokenService.java
@@ -1,0 +1,7 @@
+package com.twentyone.steachserver.domain.auth.service;
+
+import com.twentyone.steachserver.domain.auth.model.LoginCredential;
+
+public interface TempTokenService {
+    void validateToken(String token, LoginCredential credential);
+}

--- a/src/main/java/com/twentyone/steachserver/domain/auth/service/TempTokenServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/auth/service/TempTokenServiceImpl.java
@@ -1,0 +1,19 @@
+package com.twentyone.steachserver.domain.auth.service;
+
+import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
+import com.twentyone.steachserver.domain.auth.model.LoginCredential;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempTokenServiceImpl implements TempTokenService {
+    private final JwtService jwtService;
+
+    @Override
+    public void validateToken(String token, LoginCredential credential) {
+        if (!jwtService.isTempTokenValid(token, credential)) {
+            throw new ForbiddenException("토큰이 유효하지 않음");
+        }
+    }
+}

--- a/src/main/java/com/twentyone/steachserver/domain/curriculum/controller/CurriculumController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/curriculum/controller/CurriculumController.java
@@ -94,4 +94,14 @@ public class CurriculumController {
             @AuthenticationPrincipal Teacher teacher) {
         return ResponseEntity.ok(curriculumService.updateCurriculum(curriculumId, teacher, request));
     }
+
+    @Secured("ROLE_TEACHER")
+    @DeleteMapping("/{curriculum_id}")
+    public ResponseEntity<Void> deleteCurriculum(
+            @PathVariable("curriculum_id") Integer curriculumId,
+            @AuthenticationPrincipal Teacher teacher) {
+        curriculumService.deleteCurriculum(teacher, curriculumId);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/curriculum/service/CurriculumService.java
@@ -28,4 +28,6 @@ public interface CurriculumService {
                                             int weekdaysBitmask);
 
     CurriculumDetailResponse updateCurriculum(Integer curriculumId, Teacher teacher, CurriculumAddRequest request);
+
+    void deleteCurriculum(Teacher teacher, Integer curriculumId);
 }

--- a/src/main/java/com/twentyone/steachserver/domain/curriculum/service/CurriculumServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/curriculum/service/CurriculumServiceImpl.java
@@ -22,12 +22,12 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.twentyone.steachserver.global.error.ResourceNotFoundException;
 import com.twentyone.steachserver.util.WeekdayBitmaskUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -209,6 +209,19 @@ public class CurriculumServiceImpl implements CurriculumService {
         );
 
         return CurriculumDetailResponse.fromDomain(curriculum);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCurriculum(Teacher teacher, Integer curriculumId) {
+        Curriculum curriculum = curriculumRepository.findById(curriculumId)
+                .orElseThrow(() -> new ResourceNotFoundException("커리큘럼을 찾을 수 없음"));
+
+        if (!curriculum.getTeacher().equals(teacher)) {
+            throw new ForbiddenException("커리큘럼을 만든 사람이 아님. 권한없음");
+        }
+
+        curriculumRepository.delete(curriculum);
     }
 
     private int getBitmaskForDayOfWeek(DayOfWeek dayOfWeek) {

--- a/src/main/java/com/twentyone/steachserver/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/lecture/controller/LectureController.java
@@ -11,6 +11,7 @@ import com.twentyone.steachserver.domain.lecture.error.LectureTimeNotYetExceptio
 import com.twentyone.steachserver.domain.lecture.model.Lecture;
 import com.twentyone.steachserver.domain.lecture.service.LectureService;
 import com.twentyone.steachserver.domain.member.model.Student;
+import com.twentyone.steachserver.domain.member.model.Teacher;
 import com.twentyone.steachserver.domain.statistic.service.StatisticService;
 import com.twentyone.steachserver.domain.studentLecture.service.StudentLectureService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,11 +29,9 @@ import java.util.Optional;
 @RequestMapping("/api/v1/lectures")
 @RequiredArgsConstructor
 public class LectureController {
-
     private final LectureService lectureService;
     private final StudentLectureService studentLectureService;
     private final StatisticService statisticService;
-
 
     @Operation(summary = "[공통] 강의에 대한 다양한 정보 반환", description = "무조건 200을 반환, 강의에 대해서 시작 전 강의면 시작 전 형태로, 끝난 강의는 끝난형태로 반환.")
     @GetMapping("/{lectureId}")
@@ -86,6 +85,13 @@ public class LectureController {
     @PatchMapping("/start/{lectureId}")
     public ResponseEntity<?> updateRealStartTime(@PathVariable("lectureId") Integer lectureId) {
         lectureService.updateRealStartTime(lectureId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{lectureId}")
+    public ResponseEntity<?> deleteLecture(@PathVariable("lectureId") Integer lectureId, @AuthenticationPrincipal Teacher teacher) {
+        lectureService.delete(lectureId, teacher);
+
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/lecture/service/LectureService.java
@@ -7,6 +7,7 @@ import com.twentyone.steachserver.domain.lecture.dto.LectureBeforeStartingRespon
 import com.twentyone.steachserver.domain.lecture.dto.LectureListResponseDto;
 import com.twentyone.steachserver.domain.lecture.dto.update.UpdateLectureRequestDto;
 import com.twentyone.steachserver.domain.lecture.model.Lecture;
+import com.twentyone.steachserver.domain.member.model.Teacher;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +36,6 @@ public interface LectureService {
     LectureListResponseDto findByCurriculum(Integer curriculumId);
 
     void addVolunteerMinute(Lecture updateLecture);
+
+    void delete(Integer lectureId, Teacher teacher);
 }

--- a/src/main/java/com/twentyone/steachserver/domain/lecture/service/LectureServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/lecture/service/LectureServiceImpl.java
@@ -1,5 +1,6 @@
 package com.twentyone.steachserver.domain.lecture.service;
 
+import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
 import com.twentyone.steachserver.domain.classroom.model.Classroom;
 import com.twentyone.steachserver.domain.curriculum.model.Curriculum;
 import com.twentyone.steachserver.domain.lecture.dto.*;
@@ -10,10 +11,12 @@ import com.twentyone.steachserver.domain.lecture.repository.LectureRepository;
 
 import com.twentyone.steachserver.domain.lecture.validator.LectureValidator;
 import com.twentyone.steachserver.domain.member.model.Student;
+import com.twentyone.steachserver.domain.member.model.Teacher;
 import com.twentyone.steachserver.domain.member.repository.StudentRepository;
 import com.twentyone.steachserver.domain.studentLecture.model.StudentLecture;
 import com.twentyone.steachserver.domain.studentLecture.repository.StudentLectureQueryRepository;
 import com.twentyone.steachserver.domain.studentLecture.repository.StudentLectureRepository;
+import com.twentyone.steachserver.global.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,12 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class LectureServiceImpl implements LectureService {
-
     private final LectureRepository lectureRepository;
     private final LectureQueryRepository lectureQueryRepository;
     private final StudentRepository studentRepository;
@@ -143,8 +144,20 @@ public class LectureServiceImpl implements LectureService {
                 }
             }
             curriculum.getTeacher().updateVolunteerMinute(volunteerMinute);
-
         }
+    }
+
+    @Override
+    @Transactional
+    public void delete(Integer lectureId, Teacher teacher) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new ResourceNotFoundException("lecture not found"));
+
+        if (!lecture.getCurriculum().getTeacher().equals(teacher)) {
+            throw new ForbiddenException("커리큘럼을 만든 사람만 수정이 가능. 권한이 없음");
+        }
+
+        lectureRepository.delete(lecture);
     }
 
     @Override
@@ -181,6 +194,5 @@ public class LectureServiceImpl implements LectureService {
                 .orElseThrow(() -> new IllegalArgumentException("lecture not found"));
         return CompletedLecturesResponseDto.of(lectureBeforeStartingResponseDto, studentInfoByLecture, lecture);
     }
-
 }
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/MemberInfoResponse.java
@@ -7,6 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class MemberInfoResponse {
     protected String username;
-    protected String name;
+    protected String nickname;
     protected String email;
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StudentInfoRequest {
-    private String name;
+    private String nickname;
     private String email;
     private String password;
     private String passwordAuthToken; //수정을 위한 임시토큰 -> check/password API이용

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
@@ -10,5 +10,6 @@ import lombok.NoArgsConstructor;
 public class StudentInfoRequest {
     private String name;
     private String email;
+    private String password;
     private String passwordAuthToken; //수정을 위한 임시토큰 -> check/password API이용
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 public class StudentInfoRequest {
     private String name;
     private String email;
-    private String tempToken; //수정을 위한 임시토큰 -> check/password API이용
+    private String passwordAuthToken; //수정을 위한 임시토큰 -> check/password API이용
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class StudentInfoRequest {
     private String name;
     private String email;
+    private String tempToken; //수정을 위한 임시토큰 -> check/password API이용
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoRequest.java
@@ -1,9 +1,14 @@
 package com.twentyone.steachserver.domain.member.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/*
+nickname, email, password는 null로 들어오면 수정되지 않음
+passwordAuthToken은 필수로 넣어줘야함
+*/
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -11,5 +16,7 @@ public class StudentInfoRequest {
     private String nickname;
     private String email;
     private String password;
+
+    @NotNull
     private String passwordAuthToken; //수정을 위한 임시토큰 -> check/password API이용
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoResponse.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/StudentInfoResponse.java
@@ -10,7 +10,7 @@ public class StudentInfoResponse extends MemberInfoResponse {
     public static StudentInfoResponse fromDomain(Student student) {
         StudentInfoResponse response = new StudentInfoResponse();
         response.username = student.getUsername();
-        response.name = student.getName();
+        response.nickname = student.getName();
         response.email = student.getEmail();
 
         return response;

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
@@ -16,4 +16,5 @@ public class TeacherInfoRequest {
     private String briefIntroduction;
     private String academicBackground;
     private String specialization;
+    private String tempToken;
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
@@ -16,5 +16,5 @@ public class TeacherInfoRequest {
     private String briefIntroduction;
     private String academicBackground;
     private String specialization;
-    private String tempToken;
+    private String passwordAuthToken;
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class TeacherInfoRequest {
     private String name;
     private String email;
+    private String password;
     private String pathQualification;
     private String briefIntroduction;
     private String academicBackground;

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
@@ -1,10 +1,16 @@
 package com.twentyone.steachserver.domain.member.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/*
+nickname, email, password는 null로 들어오면 수정되지 않음
+briefIntroduction, academicBackground, specilization은 무조건 넣어줘야함. 아니면 null처리됨
+passwordAuthToken은 필수로 넣어줘야함
+*/
 @Builder
 @Getter
 @NoArgsConstructor
@@ -16,5 +22,6 @@ public class TeacherInfoRequest {
     private String briefIntroduction;
     private String academicBackground;
     private String specialization;
+    @NotNull
     private String passwordAuthToken;
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TeacherInfoRequest {
-    private String name;
+    private String nickname;
     private String email;
     private String password;
     private String briefIntroduction;

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoRequest.java
@@ -13,7 +13,6 @@ public class TeacherInfoRequest {
     private String name;
     private String email;
     private String password;
-    private String pathQualification;
     private String briefIntroduction;
     private String academicBackground;
     private String specialization;

--- a/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoResponse.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/dto/TeacherInfoResponse.java
@@ -15,7 +15,7 @@ public class TeacherInfoResponse extends MemberInfoResponse {
     public static TeacherInfoResponse fromDomain(Teacher teacher) {
         TeacherInfoResponse response = new TeacherInfoResponse();
         response.username = teacher.getUsername();
-        response.name = teacher.getName();
+        response.nickname = teacher.getName();
         response.email = teacher.getEmail();
         response.volunteerTime = teacher.getVolunteerTime();
         response.briefIntroduction = teacher.getBriefIntroduction();

--- a/src/main/java/com/twentyone/steachserver/domain/member/memberController/StudentController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/memberController/StudentController.java
@@ -8,6 +8,7 @@ import com.twentyone.steachserver.domain.member.model.Student;
 import com.twentyone.steachserver.domain.member.service.StudentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -41,7 +42,7 @@ public class StudentController {
                     "<br/> ✅ /check/password 를 통해 발급받은 임시 토큰을 넣어줘야 성공합니다. 아니면 403이 나옴"
     )
     @PatchMapping
-    public ResponseEntity<StudentInfoResponse> updateInfo(@RequestBody StudentInfoRequest request, @AuthenticationPrincipal Student student) {
+    public ResponseEntity<StudentInfoResponse> updateInfo(@RequestBody @Valid StudentInfoRequest request, @AuthenticationPrincipal Student student) {
         return ResponseEntity.ok(studentService.updateInfo(request, student));
     }
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/memberController/StudentController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/memberController/StudentController.java
@@ -35,7 +35,11 @@ public class StudentController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "[학생] 회원정보 수정", description = "name과 email은 값을 null이나 빈칸으로 넣어줄 경우 값이 변경되지 않습니다! 빈칸이 되면 안되기 때문..")
+    @Operation(
+            summary = "[학생] 회원정보 수정",
+            description = "✅ name, email, password는 값을 null이나 빈칸으로 넣어줄 경우 값이 변경되지 않습니다! 빈칸이 되면 안되기 때문.. " +
+                    "<br/> ✅ /check/password 를 통해 발급받은 임시 토큰을 넣어줘야 성공합니다. 아니면 403이 나옴"
+    )
     @PatchMapping
     public ResponseEntity<StudentInfoResponse> updateInfo(@RequestBody StudentInfoRequest request, @AuthenticationPrincipal Student student) {
         return ResponseEntity.ok(studentService.updateInfo(request, student));

--- a/src/main/java/com/twentyone/steachserver/domain/member/memberController/TeacherController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/memberController/TeacherController.java
@@ -35,7 +35,7 @@ public class TeacherController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "[강사] 회원정보 수정", description = "name과 email은 값을 null이나 빈칸으로 넣어줄 경우 값이 변경되지 않습니다! 빈칸이 되면 안되기 때문..")
+    @Operation(summary = "[강사] 회원정보 수정", description = "name, email, password는 값을 null이나 빈칸으로 넣어줄 경우 값이 변경되지 않습니다! 빈칸이 되면 안되기 때문.. <br/>")
     @PatchMapping
     public ResponseEntity<TeacherInfoResponse> updateInfo(@RequestBody TeacherInfoRequest request, @AuthenticationPrincipal Teacher teacher) {
         return ResponseEntity.ok(teacherService.updateInfo(request, teacher));

--- a/src/main/java/com/twentyone/steachserver/domain/member/memberController/TeacherController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/memberController/TeacherController.java
@@ -35,7 +35,12 @@ public class TeacherController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "[강사] 회원정보 수정", description = "name, email, password는 값을 null이나 빈칸으로 넣어줄 경우 값이 변경되지 않습니다! 빈칸이 되면 안되기 때문.. <br/>")
+    @Operation(
+            summary = "[강사] 회원정보 수정",
+            description = "✅ name, email, password는 값을 null이나 빈칸으로 넣어줄 경우 값이 변경되지 않습니다! 빈칸이 되면 안되기 때문.. " +
+                    "<br/> ✅ briefIntroduction, academicBackground, specialization은 필수로 넣어줘야 null로 설정되지 않습니다." +
+                    "<br/> ✅ /check/password 를 통해 발급받은 임시 토큰을 넣어줘야 성공합니다. 아니면 403이 나옴"
+    )
     @PatchMapping
     public ResponseEntity<TeacherInfoResponse> updateInfo(@RequestBody TeacherInfoRequest request, @AuthenticationPrincipal Teacher teacher) {
         return ResponseEntity.ok(teacherService.updateInfo(request, teacher));

--- a/src/main/java/com/twentyone/steachserver/domain/member/memberController/TeacherController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/memberController/TeacherController.java
@@ -8,6 +8,7 @@ import com.twentyone.steachserver.domain.member.model.Teacher;
 import com.twentyone.steachserver.domain.member.service.TeacherService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -42,7 +43,7 @@ public class TeacherController {
                     "<br/> ✅ /check/password 를 통해 발급받은 임시 토큰을 넣어줘야 성공합니다. 아니면 403이 나옴"
     )
     @PatchMapping
-    public ResponseEntity<TeacherInfoResponse> updateInfo(@RequestBody TeacherInfoRequest request, @AuthenticationPrincipal Teacher teacher) {
+    public ResponseEntity<TeacherInfoResponse> updateInfo(@RequestBody @Valid TeacherInfoRequest request, @AuthenticationPrincipal Teacher teacher) {
         return ResponseEntity.ok(teacherService.updateInfo(request, teacher));
     }
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/model/Student.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/model/Student.java
@@ -61,13 +61,17 @@ public class Student extends LoginCredential {
         this.studentCurricula.add(studentCurriculum);
     }
 
-    public void updateInfo(String name, String email) {
+    public void updateInfo(String name, String email, String password) {
         if (name != null && !name.equals("")) {
             this.name = name;
         }
 
         if (email != null && !email.equals("")) {
             this.email = email;
+        }
+
+        if (password != null & !password.equals("")) {
+            this.setPassword(password);
         }
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/member/model/Student.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/model/Student.java
@@ -47,12 +47,12 @@ public class Student extends LoginCredential {
     @OneToMany(mappedBy = "student")
     private List<StudentLecture> studentLectures = new ArrayList<>();
 
-    public static Student of(String username, String password, String name, String email) {
+    public static Student of(String username, String password, String nickname, String email) {
         Student student = new Student();
         student.setUsername(username);
         student.setPassword(password);
         student.setEmail(email);
-        student.name = name;
+        student.name = nickname;
 
         return student;
     }
@@ -61,9 +61,9 @@ public class Student extends LoginCredential {
         this.studentCurricula.add(studentCurriculum);
     }
 
-    public void updateInfo(String name, String email, String password) {
-        if (name != null && !name.equals("")) {
-            this.name = name;
+    public void updateInfo(String nickname, String email, String password) {
+        if (nickname != null && !nickname.equals("")) {
+            this.name = nickname;
         }
 
         if (email != null && !email.equals("")) {

--- a/src/main/java/com/twentyone/steachserver/domain/member/model/Teacher.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/model/Teacher.java
@@ -56,13 +56,17 @@ public class Teacher extends LoginCredential{
         return teacher;
     }
 
-    public void updateInfo(String name, String email, String briefIntroduction, String academicBackground, String specialization) {
+    public void updateInfo(String name, String email, String briefIntroduction, String academicBackground, String specialization, String password) {
         if (name != null && !name.equals("")) {
             this.name = name;
         }
 
         if (email != null && !email.equals("")) {
             this.email = email;
+        }
+
+        if (password != null & !password.equals("")) {
+            this.setPassword(password);
         }
 
         this.briefIntroduction = briefIntroduction;

--- a/src/main/java/com/twentyone/steachserver/domain/member/model/Teacher.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/model/Teacher.java
@@ -44,21 +44,21 @@ public class Teacher extends LoginCredential{
         return teacher.getId().equals(this.getId());
     }
 
-    public static Teacher of(String username, String password, String name, String email, String pathQualification) {
+    public static Teacher of(String username, String password, String nickname, String email, String pathQualification) {
         Teacher teacher = new Teacher();
 
         teacher.setUsername(username);
         teacher.setPassword(password);
-        teacher.name = name;
+        teacher.name = nickname;
         teacher.email = email;
         teacher.pathQualification = pathQualification;
 
         return teacher;
     }
 
-    public void updateInfo(String name, String email, String briefIntroduction, String academicBackground, String specialization, String password) {
-        if (name != null && !name.equals("")) {
-            this.name = name;
+    public void updateInfo(String nickname, String email, String briefIntroduction, String academicBackground, String specialization, String password) {
+        if (nickname != null && !nickname.equals("")) {
+            this.name = nickname;
         }
 
         if (email != null && !email.equals("")) {

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
@@ -1,7 +1,6 @@
 package com.twentyone.steachserver.domain.member.service;
 
-import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
-import com.twentyone.steachserver.domain.auth.service.JwtService;
+import com.twentyone.steachserver.domain.auth.service.TempTokenService;
 import com.twentyone.steachserver.domain.member.dto.StudentInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.StudentInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Student;
@@ -17,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudentServiceImpl implements StudentService {
     private final StudentRepository studentRepository;
-    private final JwtService jwtService;
+    private final TempTokenService tempTokenService;
 
     @Override
     public StudentInfoResponse getInfo(Student student) {
@@ -28,10 +27,7 @@ public class StudentServiceImpl implements StudentService {
     @Transactional
     public StudentInfoResponse updateInfo(StudentInfoRequest request, Student student) {
         //TODO 403 401 정하기
-        //임시토큰 검증
-        if (!jwtService.isTokenValid(request.getTempToken(), student)) {
-            throw new ForbiddenException("토큰이 유효하지 않음");
-        }
+        tempTokenService.validateToken(request.getTempToken(), student);
 
         student.updateInfo(request.getName(), request.getEmail());
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
@@ -7,6 +7,7 @@ import com.twentyone.steachserver.domain.member.model.Student;
 import com.twentyone.steachserver.domain.member.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentServiceImpl implements StudentService {
     private final StudentRepository studentRepository;
     private final PasswordAuthTokenService passwordAuthTokenService;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public StudentInfoResponse getInfo(Student student) {
@@ -29,7 +31,8 @@ public class StudentServiceImpl implements StudentService {
         //TODO 403 401 정하기
         passwordAuthTokenService.validateToken(request.getPasswordAuthToken(), student);
 
-        student.updateInfo(request.getName(), request.getEmail());
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        student.updateInfo(request.getName(), request.getEmail(), encodedPassword);
 
         return StudentInfoResponse.fromDomain(student);
     }

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
@@ -1,6 +1,6 @@
 package com.twentyone.steachserver.domain.member.service;
 
-import com.twentyone.steachserver.domain.auth.service.TempTokenService;
+import com.twentyone.steachserver.domain.auth.service.PasswordAuthTokenService;
 import com.twentyone.steachserver.domain.member.dto.StudentInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.StudentInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Student;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudentServiceImpl implements StudentService {
     private final StudentRepository studentRepository;
-    private final TempTokenService tempTokenService;
+    private final PasswordAuthTokenService passwordAuthTokenService;
 
     @Override
     public StudentInfoResponse getInfo(Student student) {
@@ -27,7 +27,7 @@ public class StudentServiceImpl implements StudentService {
     @Transactional
     public StudentInfoResponse updateInfo(StudentInfoRequest request, Student student) {
         //TODO 403 401 정하기
-        tempTokenService.validateToken(request.getTempToken(), student);
+        passwordAuthTokenService.validateToken(request.getPasswordAuthToken(), student);
 
         student.updateInfo(request.getName(), request.getEmail());
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
@@ -32,7 +32,7 @@ public class StudentServiceImpl implements StudentService {
         passwordAuthTokenService.validateToken(request.getPasswordAuthToken(), student);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-        student.updateInfo(request.getName(), request.getEmail(), encodedPassword);
+        student.updateInfo(request.getNickname(), request.getEmail(), encodedPassword);
 
         return StudentInfoResponse.fromDomain(student);
     }

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/StudentServiceImpl.java
@@ -1,5 +1,7 @@
 package com.twentyone.steachserver.domain.member.service;
 
+import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
+import com.twentyone.steachserver.domain.auth.service.JwtService;
 import com.twentyone.steachserver.domain.member.dto.StudentInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.StudentInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Student;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudentServiceImpl implements StudentService {
     private final StudentRepository studentRepository;
+    private final JwtService jwtService;
 
     @Override
     public StudentInfoResponse getInfo(Student student) {
@@ -24,6 +27,12 @@ public class StudentServiceImpl implements StudentService {
     @Override
     @Transactional
     public StudentInfoResponse updateInfo(StudentInfoRequest request, Student student) {
+        //TODO 403 401 정하기
+        //임시토큰 검증
+        if (!jwtService.isTokenValid(request.getTempToken(), student)) {
+            throw new ForbiddenException("토큰이 유효하지 않음");
+        }
+
         student.updateInfo(request.getName(), request.getEmail());
 
         return StudentInfoResponse.fromDomain(student);

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
@@ -1,7 +1,6 @@
 package com.twentyone.steachserver.domain.member.service;
 
-import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
-import com.twentyone.steachserver.domain.auth.service.JwtService;
+import com.twentyone.steachserver.domain.auth.service.TempTokenService;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Teacher;
@@ -13,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TeacherServiceImpl implements TeacherService {
-    private final JwtService jwtService;
+    private final TempTokenService tempTokenService;
 
     @Override
     public TeacherInfoResponse getInfo(Teacher teacher) {
@@ -24,9 +23,7 @@ public class TeacherServiceImpl implements TeacherService {
     @Override
     public TeacherInfoResponse updateInfo(TeacherInfoRequest request, Teacher teacher) {
         //임시토큰 검증
-        if (!jwtService.isTempTokenValid(request.getTempToken(), teacher)) {
-            throw new ForbiddenException("토큰이 유효하지 않음");
-        }
+        tempTokenService.validateToken(request.getTempToken(), teacher);
 
         teacher.updateInfo(request.getName(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization());
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
@@ -1,6 +1,6 @@
 package com.twentyone.steachserver.domain.member.service;
 
-import com.twentyone.steachserver.domain.auth.service.TempTokenService;
+import com.twentyone.steachserver.domain.auth.service.PasswordAuthTokenService;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Teacher;
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TeacherServiceImpl implements TeacherService {
-    private final TempTokenService tempTokenService;
+    private final PasswordAuthTokenService passwordAuthTokenService;
 
     @Override
     public TeacherInfoResponse getInfo(Teacher teacher) {
@@ -23,7 +23,7 @@ public class TeacherServiceImpl implements TeacherService {
     @Override
     public TeacherInfoResponse updateInfo(TeacherInfoRequest request, Teacher teacher) {
         //임시토큰 검증
-        tempTokenService.validateToken(request.getTempToken(), teacher);
+        passwordAuthTokenService.validateToken(request.getPasswordAuthToken(), teacher);
 
         teacher.updateInfo(request.getName(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization());
 

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
@@ -5,6 +5,7 @@ import com.twentyone.steachserver.domain.member.dto.TeacherInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Teacher;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TeacherServiceImpl implements TeacherService {
     private final PasswordAuthTokenService passwordAuthTokenService;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public TeacherInfoResponse getInfo(Teacher teacher) {
@@ -25,7 +27,8 @@ public class TeacherServiceImpl implements TeacherService {
         //임시토큰 검증
         passwordAuthTokenService.validateToken(request.getPasswordAuthToken(), teacher);
 
-        teacher.updateInfo(request.getName(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization());
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        teacher.updateInfo(request.getName(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization(), encodedPassword);
 
         return TeacherInfoResponse.fromDomain(teacher);
     }

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
@@ -1,5 +1,7 @@
 package com.twentyone.steachserver.domain.member.service;
 
+import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
+import com.twentyone.steachserver.domain.auth.service.JwtService;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoRequest;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoResponse;
 import com.twentyone.steachserver.domain.member.model.Teacher;
@@ -11,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TeacherServiceImpl implements TeacherService {
+    private final JwtService jwtService;
+
     @Override
     public TeacherInfoResponse getInfo(Teacher teacher) {
         return TeacherInfoResponse.fromDomain(teacher);
@@ -19,6 +23,11 @@ public class TeacherServiceImpl implements TeacherService {
     @Transactional
     @Override
     public TeacherInfoResponse updateInfo(TeacherInfoRequest request, Teacher teacher) {
+        //임시토큰 검증
+        if (!jwtService.isTempTokenValid(request.getTempToken(), teacher)) {
+            throw new ForbiddenException("토큰이 유효하지 않음");
+        }
+
         teacher.updateInfo(request.getName(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization());
 
         return TeacherInfoResponse.fromDomain(teacher);

--- a/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/member/service/TeacherServiceImpl.java
@@ -28,7 +28,7 @@ public class TeacherServiceImpl implements TeacherService {
         passwordAuthTokenService.validateToken(request.getPasswordAuthToken(), teacher);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-        teacher.updateInfo(request.getName(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization(), encodedPassword);
+        teacher.updateInfo(request.getNickname(), request.getEmail(), request.getBriefIntroduction(), request.getAcademicBackground(), request.getSpecialization(), encodedPassword);
 
         return TeacherInfoResponse.fromDomain(teacher);
     }

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/controller/QuizController.java
@@ -30,7 +30,7 @@ public class QuizController {
     @PostMapping("/{lectureId}")
     public ResponseEntity<QuizResponseDto> createQuiz(@PathVariable("lectureId")Integer lectureId, @RequestBody QuizRequestDto request) throws Exception {
         return quizService.createQuiz(lectureId, request)
-                .map(quiz -> ResponseEntity.status(HttpStatus.CREATED).body(QuizResponseDto.createQuizResponseDto(lectureId, request)))
+                .map(quiz -> ResponseEntity.status(HttpStatus.CREATED).body(QuizResponseDto.createQuizResponseDto(lectureId, request, quiz.getId())))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
     }
 

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/controller/QuizController.java
@@ -1,5 +1,6 @@
 package com.twentyone.steachserver.domain.quiz.controller;
 
+import com.twentyone.steachserver.domain.member.model.Teacher;
 import com.twentyone.steachserver.domain.quiz.dto.QuizRequestDto;
 import com.twentyone.steachserver.domain.quiz.dto.QuizResponseDto;
 import com.twentyone.steachserver.domain.quiz.dto.QuizzesResponseDto;
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -50,5 +53,13 @@ public class QuizController {
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok().body(QuizzesResponseDto.of(quizResponseDtos));
+    }
+
+    @Secured("ROLE_TEACHER")
+    @DeleteMapping("/{quiz_id}")
+    public ResponseEntity<QuizResponseDto> deleteQuiz(@PathVariable("quiz_id")Integer quizId, @AuthenticationPrincipal Teacher teacher) {
+        quizService.delete(quizId, teacher);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizRequestDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizRequestDto.java
@@ -18,6 +18,6 @@ import java.util.List;
  *   ] // 중복가능
  * }
  */
-public record QuizRequestDto(Integer quizNumber, String question, List<String> choices, List<String> answers) {
+public record QuizRequestDto(Integer quizId, Integer quizNumber, String question, List<String> choices, List<String> answers) {
 
 }

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizRequestDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizRequestDto.java
@@ -1,9 +1,5 @@
 package com.twentyone.steachserver.domain.quiz.dto;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.List;
 
 /**
@@ -18,6 +14,6 @@ import java.util.List;
  *   ] // 중복가능
  * }
  */
-public record QuizRequestDto(Integer quizId, Integer quizNumber, String question, List<String> choices, List<String> answers) {
+public record QuizRequestDto(Integer quizNumber, String question, List<String> choices, List<String> answers) {
 
 }

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizResponseDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizResponseDto.java
@@ -5,6 +5,7 @@ import com.twentyone.steachserver.domain.quiz.model.Quiz;
 import java.util.List;
 
 public record QuizResponseDto(
+        Integer quizId,
         Integer lectureId,
         Integer quizNumber,
         String question,
@@ -15,6 +16,7 @@ public record QuizResponseDto(
         allStrip(request.choices());
         allStrip(request.answers());
         return new QuizResponseDto(
+                request.quizId(),
                 lectureId,
                 request.quizNumber(),
                 request.question(),
@@ -27,6 +29,7 @@ public record QuizResponseDto(
         allStrip(choices);
         allStrip(answers);
         return new QuizResponseDto(
+                quiz.getId(),
                 quiz.getLecture().getId(),
                 quiz.getQuizNumber(),
                 quiz.getQuestion(),

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizResponseDto.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/dto/QuizResponseDto.java
@@ -12,11 +12,11 @@ public record QuizResponseDto(
         List<String> choices,
         List<String> answers
 ) {
-    public static QuizResponseDto createQuizResponseDto(Integer lectureId, QuizRequestDto request) {
+    public static QuizResponseDto createQuizResponseDto(Integer lectureId, QuizRequestDto request, Integer quizId) {
         allStrip(request.choices());
         allStrip(request.answers());
         return new QuizResponseDto(
-                request.quizId(),
+                quizId,
                 lectureId,
                 request.quizNumber(),
                 request.question(),

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/service/QuizService.java
@@ -1,5 +1,6 @@
 package com.twentyone.steachserver.domain.quiz.service;
 
+import com.twentyone.steachserver.domain.member.model.Teacher;
 import com.twentyone.steachserver.domain.quiz.dto.QuizRequestDto;
 import com.twentyone.steachserver.domain.quiz.dto.QuizResponseDto;
 import com.twentyone.steachserver.domain.quiz.model.Quiz;
@@ -17,5 +18,7 @@ public interface QuizService {
     QuizResponseDto mapToDto(Quiz quiz);
 
     List<Quiz> findAllByLectureId(Integer lectureId);
+
+    void delete(Integer quizId, Teacher teacher);
 }
 

--- a/src/main/java/com/twentyone/steachserver/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/quiz/service/QuizServiceImpl.java
@@ -1,6 +1,8 @@
 package com.twentyone.steachserver.domain.quiz.service;
 
+import com.twentyone.steachserver.domain.auth.error.ForbiddenException;
 import com.twentyone.steachserver.domain.lecture.repository.LectureRepository;
+import com.twentyone.steachserver.domain.member.model.Teacher;
 import com.twentyone.steachserver.domain.quiz.validator.QuizChoiceValidator;
 import com.twentyone.steachserver.domain.quiz.validator.QuizValidator;
 import com.twentyone.steachserver.domain.lecture.model.Lecture;
@@ -8,6 +10,7 @@ import com.twentyone.steachserver.domain.quiz.dto.QuizRequestDto;
 import com.twentyone.steachserver.domain.quiz.dto.QuizResponseDto;
 import com.twentyone.steachserver.domain.quiz.model.Quiz;
 import com.twentyone.steachserver.domain.quiz.repository.QuizRepository;
+import com.twentyone.steachserver.global.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +23,6 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class  QuizServiceImpl implements QuizService {
-
     private final QuizRepository quizRepository;
     private final LectureRepository lectureRepository;
 
@@ -73,9 +75,22 @@ public class  QuizServiceImpl implements QuizService {
         return QuizResponseDto.createQuizResponseDto(quiz, choices, answers);
     }
 
-
     @Override
     public List<Quiz> findAllByLectureId(Integer lectureId) {
         return quizRepository.findALlByLectureId(lectureId);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Integer quizId, Teacher teacher) {
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResourceNotFoundException("퀴즈를 찾을 수 없음"));
+
+        //퀴즈를 만든 사람인지 확인
+        if (!quiz.getLecture().getCurriculum().getTeacher().equals(teacher)) {
+            throw new ForbiddenException("퀴즈를 만든 사람만 삭제가 가능합니다.");
+        }
+
+        quizRepository.delete(quiz);
     }
 }

--- a/src/main/java/com/twentyone/steachserver/global/error/ResourceNotFoundException.java
+++ b/src/main/java/com/twentyone/steachserver/global/error/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.twentyone.steachserver.global.error;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException() {
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/twentyone/steachserver/domain/IntegrationTests.java
+++ b/src/test/java/com/twentyone/steachserver/domain/IntegrationTests.java
@@ -3,7 +3,6 @@ package com.twentyone.steachserver.domain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twentyone.steachserver.domain.auth.dto.LoginDto;
 import com.twentyone.steachserver.domain.auth.dto.TeacherSignUpDto;
-import com.twentyone.steachserver.domain.auth.service.JwtService;
 import com.twentyone.steachserver.domain.curriculum.dto.CurriculumAddRequest;
 import com.twentyone.steachserver.domain.curriculum.dto.CurriculumDetailResponse;
 import com.twentyone.steachserver.domain.curriculum.enums.CurriculumCategory;
@@ -18,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -91,7 +89,7 @@ class IntegrationTests {
         TeacherSignUpDto teacherSignUpDto = TeacherSignUpDto.builder()
                 .username(teacherUsername)
                 .password(teacherPassword)
-                .name(teacherName) // 필수 필드 설정
+                .nickname(teacherName) // 필수 필드 설정
                 .email(teacherEmail)
                 .build();
 
@@ -144,7 +142,7 @@ class IntegrationTests {
         teacherName = "조시현";
 
         TeacherInfoRequest updateRequest = TeacherInfoRequest.builder()
-                .name(teacherName)
+                .nickname(teacherName)
                 .email(teacherEmail)
 //                .pathQualification("updatedPathQualification")
                 .briefIntroduction("updatedBriefIntroduction")

--- a/src/test/java/com/twentyone/steachserver/domain/IntegrationTests.java
+++ b/src/test/java/com/twentyone/steachserver/domain/IntegrationTests.java
@@ -146,7 +146,7 @@ class IntegrationTests {
         TeacherInfoRequest updateRequest = TeacherInfoRequest.builder()
                 .name(teacherName)
                 .email(teacherEmail)
-                .pathQualification("updatedPathQualification")
+//                .pathQualification("updatedPathQualification")
                 .briefIntroduction("updatedBriefIntroduction")
                 .academicBackground("updatedAcademicBackground")
                 .specialization("updatedSpecialization")

--- a/src/test/java/com/twentyone/steachserver/domain/TempTest.java
+++ b/src/test/java/com/twentyone/steachserver/domain/TempTest.java
@@ -226,7 +226,6 @@ class TempTest {
         TeacherInfoRequest updateRequest = TeacherInfoRequest.builder()
                 .nickname("updatedName")
                 .email("updatedEmail@gmail.com")
-//                .pathQualification("updatedPathQualification")
                 .briefIntroduction("updatedBriefIntroduction")
                 .academicBackground("updatedAcademicBackground")
                 .specialization("updatedSpecialization")

--- a/src/test/java/com/twentyone/steachserver/domain/TempTest.java
+++ b/src/test/java/com/twentyone/steachserver/domain/TempTest.java
@@ -229,7 +229,7 @@ class TempTest {
         TeacherInfoRequest updateRequest = TeacherInfoRequest.builder()
                 .name("updatedName")
                 .email("updatedEmail@gmail.com")
-                .pathQualification("updatedPathQualification")
+//                .pathQualification("updatedPathQualification")
                 .briefIntroduction("updatedBriefIntroduction")
                 .academicBackground("updatedAcademicBackground")
                 .specialization("updatedSpecialization")

--- a/src/test/java/com/twentyone/steachserver/domain/TempTest.java
+++ b/src/test/java/com/twentyone/steachserver/domain/TempTest.java
@@ -8,7 +8,6 @@ import com.twentyone.steachserver.domain.curriculum.dto.CurriculumDetailResponse
 import com.twentyone.steachserver.domain.curriculum.enums.CurriculumCategory;
 import com.twentyone.steachserver.domain.member.dto.TeacherInfoRequest;
 import lombok.RequiredArgsConstructor;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,8 +27,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -83,7 +80,7 @@ class TempTest {
         TeacherSignUpDto teacherSignUpDto = TeacherSignUpDto.builder()
                 .username(teacherUsername)
                 .password(teacherPassword)
-                .name(teacherName) // 필수 필드 설정
+                .nickname(teacherName) // 필수 필드 설정
                 .email(teacherEmail)
                 .build();
 
@@ -227,7 +224,7 @@ class TempTest {
     void testUpdateTeacherInfo() throws Exception {
         // 강사 회원정보 수정
         TeacherInfoRequest updateRequest = TeacherInfoRequest.builder()
-                .name("updatedName")
+                .nickname("updatedName")
                 .email("updatedEmail@gmail.com")
 //                .pathQualification("updatedPathQualification")
                 .briefIntroduction("updatedBriefIntroduction")

--- a/src/test/java/com/twentyone/steachserver/domain/curriculum/service/CurriculumServiceImplTest.java
+++ b/src/test/java/com/twentyone/steachserver/domain/curriculum/service/CurriculumServiceImplTest.java
@@ -129,7 +129,7 @@ class CurriculumServiceImplTest {
                 NOW.toLocalDate(), NOW.toLocalDate(), WEEKDAY_BITMASK, NOW.toLocalTime(), NOW.toLocalTime(), MAX_ATTENDEES);
 
         //when //then
-        assertThrows(ForbiddenException.class, () -> {
+        assertThrows(RuntimeException.class, () -> {
             curriculumService.create(student, request);
         });
     }


### PR DESCRIPTION
## ⭐ 작업 분류 
- [X] 신규 기능
- [ ] 버그 수정
- [ ] 디자인 수정
- [X] 코드 수정
- [ ] 문서 수정
- [ ] 주석 추가
- [ ] 치명적 버그 수정

## ⭐ 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.
<!-- 아래 작성 -->

- 패스워드 체크 API 임시토큰 발급하도록 수정
- 회원정보 수정 시 토큰을 받도록 수정
- jwt관련 에러 수정: user가 없을 때 500 RuntimeException -> 401 UsernameNotFoundException 변경
- 토큰 만료 커스텀 에러메시지 추가
- 회원정보 수정 시 비밀번호도 같이 수정할 수 있도록 변경
- swagger 설명 추가


<br><br>
## ⭐ 작업 상세 내용
> 왜 그런 로직을 작성했는지 **자세히** 알려주세요. 👍  
기존코드에서 무엇이 수정되었는지?  
어떤 생각으로 컴포넌트를 분리하였는지?  
> >  ex) query 및 mutation 기능 연결하였습니다.  
<!-- 아래 작성 -->



<br><br>
## 리뷰 시간 🌼
> 리뷰 예상시간을 간략하게 작성 ex) 10m
<!-- 아래 작성 -->

10분

<br><br>
## 기타 메시지
> 다음 스크럼에 할일 혹은 리뷰어에게 부탁할 말을 작성하시면 됩니다.
<!-- 아래 작성 -->



<br><br>
## Preview 이미지 업로드
> 변경 사항을 참고하기 쉽게 스크린샷 이미지를 첨부해 주세요. preview를 위한 gif를 첨부해도 좋습니다.
<!-- 아래 작성 -->

![image](https://github.com/user-attachments/assets/151b3e8b-055c-4efd-bc9c-eb66cee9f9b5)



<br><br>
## 관련 이슈
> 관련있는 이슈를 알려주세요.
> ex) Close [#1](https://github.com/TEAM-2NE1/steach-server/pull/2) (#이슈)
<!-- 아래 작성 -->



<br><br><br><br><br>
<hr>
