### PR TITLE
fix: StudentLecture를 중복으로 만드는 로직 수정

### DIFF
--- a/src/main/java/com/twentyone/steachserver/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/twentyone/steachserver/domain/classroom/controller/ClassroomController.java
@@ -1,6 +1,5 @@
 package com.twentyone.steachserver.domain.classroom.controller;
 
-import com.twentyone.steachserver.domain.auth.model.LoginCredential;
 import com.twentyone.steachserver.domain.classroom.dto.ClassroomResponseDto;
 import com.twentyone.steachserver.domain.classroom.dto.UpComingClassRoomsResponseDto;
 import com.twentyone.steachserver.domain.classroom.model.Classroom;
@@ -56,12 +55,9 @@ public class ClassroomController {
     @Operation(summary = "[깅사] 선생님이 강의 시작을 누르면 교실로 들어가는 메서드", description = "무조건 200을 반환")
     @PatchMapping("/start/{lectureId}")
     public ResponseEntity<?> startClassroom(@PathVariable("lectureId") Integer lectureId) {
-        studentLectureService.createStudentLectureByLecture(lectureId);
         Classroom classroom = classroomService.createClassroom(lectureId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ClassroomResponseDto.createClassroomResponseDto(classroom));
     }
-
-
 }

--- a/src/main/java/com/twentyone/steachserver/domain/classroom/service/ClassroomServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/classroom/service/ClassroomServiceImpl.java
@@ -51,8 +51,11 @@ public class ClassroomServiceImpl implements ClassroomService {
 
         // 추후 배치처리해주면 기가 맥힐듯
         for (Lecture lecture : lectures) {
-            Classroom classroom = Classroom.createClassroom(lecture);
-            classroomRepository.save(classroom);
+            Optional<Classroom> byId = classroomRepository.findById(lecture.getId());
+            if (byId.isEmpty()) {
+                Classroom classroom = Classroom.createClassroom(lecture);
+                classroomRepository.save(classroom);
+            }
         }
     }
 

--- a/src/main/java/com/twentyone/steachserver/domain/studentLecture/service/StudentLectureService.java
+++ b/src/main/java/com/twentyone/steachserver/domain/studentLecture/service/StudentLectureService.java
@@ -1,14 +1,9 @@
 package com.twentyone.steachserver.domain.studentLecture.service;
 
-import com.twentyone.steachserver.domain.studentLecture.model.StudentLecture;
-
-import java.util.List;
-import java.util.Optional;
-
 public interface StudentLectureService {
     void saveTimeFocusTime(Integer studentId, Integer lectureId, Integer focusTime);
 
     void updateStudentLectureByFinishLecture(Integer lectureId);
 
-    void createStudentLectureByLecture(Integer lectureId);
+//    void createStudentLectureByLecture(Integer lectureId);
 }

--- a/src/main/java/com/twentyone/steachserver/domain/studentLecture/service/StudentLectureServiceImpl.java
+++ b/src/main/java/com/twentyone/steachserver/domain/studentLecture/service/StudentLectureServiceImpl.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
 
 
 @Service
@@ -83,13 +82,13 @@ public class StudentLectureServiceImpl implements StudentLectureService {
         studentLectureQueryRepository.updateStudentLectureByFinishLecture(lectureId);
     }
 
-    @Override
-    public void createStudentLectureByLecture(Integer lectureId) {
-        List<Student> students = lectureQueryRepository.getStudentIds(lectureId);
-
-        for (Student student : students) {
-            studentLectureRepository.save(StudentLecture.of(student, lectureRepository.getReferenceById(lectureId)));
-        }
-
-    }
+//    @Override
+//    @Transactional
+//    public void createStudentLectureByLecture(Integer lectureId) {
+//        List<Student> students = lectureQueryRepository.getStudentIds(lectureId);
+//
+//        for (Student student : students) {
+//            studentLectureRepository.save(StudentLecture.of(student, lectureRepository.getReferenceById(lectureId)));
+//        }
+//    }
 }

--- a/src/test/java/com/twentyone/steachserver/TestScenario1.java
+++ b/src/test/java/com/twentyone/steachserver/TestScenario1.java
@@ -150,7 +150,6 @@ public class TestScenario1 {
         /* FIXME 8. 강의시작 1 =========================================================================================== */
         /* FIXME 8-1 클래스룸 들어가기 */
         Integer lectureId1 = lectures.get(0);
-        studentLectureService.createStudentLectureByLecture(lectureId1);
         classroomService.createClassroom(lectureId1);
 
         /* FIXME 8-2. 강의 진짜 시작 */
@@ -213,7 +212,6 @@ public class TestScenario1 {
         /* FIXME 9. 강의시작 2 =========================================================================================== */
         /* FIXME 9-1 클래스룸 들어가기 */
         lectureId1 = lectures.get(1);
-        studentLectureService.createStudentLectureByLecture(lectureId1);
         classroomService.createClassroom(lectureId1);
 
         /* FIXME 9-2. 강의 진짜 시작 */


### PR DESCRIPTION
## ⭐ 작업 분류
- [ ] 테스트
- [ ] 신규 기능
- [ ] 코드 수정
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업(주석, 스타일)

## ✅ Check List 
> 모든 항목에 대해서 확인해주세요.
- [X] 테스트가 전부 통과되었나요?  
- [X] 빌드는 성공했나요?
- [X] 모든 commit이 push 되었나요?
- [X] merge할 branch를 확인했나요?
- [X] Assignee를 지정했나요?
- [X] Label을 지정했나요?

## Test Screenshot
<!-- 아래 첨부 -->

![image](https://github.com/user-attachments/assets/06056f30-507e-4649-a4f2-fc6aa9531d36)


## ⭐ 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.
<!-- 아래 작성 -->

- studentLecture가 수강신청 시, 강의 시작 시 중복으로 만들어짐
- student_id와 lecture_id는 unique이기 때문에 오류가 없지만, 중복로직이라 수정이 필요하다고 판단함
- 학생이 다가오는 강의를 조회할 때 사용할 수 있도록, 학생_강의는 미리 만들어져있는 게 좋겠다고 판단함. 그래서 수강신청 로직에만 살려줌
- 관련 테스트코드도 수정, 메서드도 삭제



<br><br>
## ⭐ 작업 상세 내용
> 왜 그런 로직을 작성했는지 **자세히** 알려주세요. 👍  
기존코드에서 무엇이 수정되었는지?  
어떤 생각으로 컴포넌트를 분리하였는지?  
> >  ex) query 및 mutation 기능 연결하였습니다.  
<!-- 아래 작성 -->



<br><br>
## 리뷰 시간 🌼
> 리뷰 예상시간을 간략하게 작성 ex) 10m
<!-- 아래 작성 -->



<br><br>
## 기타 메시지
> 다음 스크럼에 할일 혹은 리뷰어에게 부탁할 말을 작성하시면 됩니다.
<!-- 아래 작성 -->



<br><br>
## 이미지 업로드
> 변경 사항을 참고하기 쉽게 스크린샷 이미지를 첨부해 주세요. (시연을 위한 gif를 첨부해도 좋습니다.)
<!-- 아래 작성 -->



<br><br>
## 관련 이슈
> 관련있는 이슈를 알려주세요.
> ex) Close #1 (#이슈번호)
<!-- 아래 작성 -->



<br><br><br><br><br>
<hr>
